### PR TITLE
fix(trader): Fix Yield Sign Trading

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -512,7 +512,7 @@ RegisterNetEvent('SignRobbery:Trade:Menu', function()
         { header = "Turn Left Signs", txt = "Trade", params = { event = "SignRobbery:TradeAnim", args = 6 } },
         { header = "Turn Right Signs", txt = "Trade", params = { event = "SignRobbery:TradeAnim", args = 7 } },
         { header = "No Trespassing Signs", txt = "Trade", params = { event = "SignRobbery:TradeAnim", args = 8 } },
-        { header = "Yield Signs", txt = "Trade", params = { event = "SignRobbery:TradeAnim", args = 8 } },
+        { header = "Yield Signs", txt = "Trade", params = { event = "SignRobbery:TradeAnim", args = 9 } },
         { header = "", txt = "❌ Close", params = { event = "SignRobbery:CloseMenu" } },
     })
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -225,7 +225,7 @@ RegisterServerEvent("SignRobbery:TradeItems", function(data)
 		else
 			TriggerClientEvent('QBCore:Notify', src, "You Do Not Have Enough Items")
 		end
-	elseif data == 8 then
+	elseif data == 9 then
 		if Player.Functions.GetItemByName('yieldsign') ~= nil and Player.Functions.GetItemByName('yieldsign').amount >= 1 then
 			Player.Functions.RemoveItem("yieldsign", "1")
 			TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items["yieldsign"], 'remove', 1)


### PR DESCRIPTION
Yield sign was set to the same ID as "No Trespassing" signs. This changes the arg/ID to 9 to allow trading.